### PR TITLE
add modelscope text2video extension

### DIFF
--- a/index.json
+++ b/index.json
@@ -721,6 +721,13 @@
             "tags": ["tab", "animation"]
         },
         {
+            "name": "ModelScope text2video",
+            "url": "https://github.com/deforum-art/sd-webui-modelscope-text2video.git",
+            "description": "Preserves the UI state after reload/restart.",
+            "added": "2023-03-19",
+            "tags": ["tab", "animation"]
+        },
+        {
             "name": "VRAM Estimator",
             "url": "https://github.com/space-nuko/a1111-stable-diffusion-webui-vram-estimator.git",
             "description": "Runs txt2img, img2img, highres-fix at increasing dimensions and batch sizes until OOM, and outputs data to graph.",

--- a/index.json
+++ b/index.json
@@ -723,7 +723,7 @@
         {
             "name": "ModelScope text2video",
             "url": "https://github.com/deforum-art/sd-webui-modelscope-text2video.git",
-            "description": "Preserves the UI state after reload/restart.",
+            "description": "Implementation of ModelScope text2video using only Auto1111 webui dependencies.",
             "added": "2023-03-19",
             "tags": ["tab", "animation"]
         },

--- a/index.json
+++ b/index.json
@@ -721,13 +721,6 @@
             "tags": ["tab", "animation"]
         },
         {
-            "name": "ModelScope text2video",
-            "url": "https://github.com/deforum-art/sd-webui-modelscope-text2video.git",
-            "description": "Implementation of ModelScope text2video using only Auto1111 webui dependencies.",
-            "added": "2023-03-19",
-            "tags": ["tab", "animation"]
-        },
-        {
             "name": "VRAM Estimator",
             "url": "https://github.com/space-nuko/a1111-stable-diffusion-webui-vram-estimator.git",
             "description": "Runs txt2img, img2img, highres-fix at increasing dimensions and batch sizes until OOM, and outputs data to graph.",
@@ -789,6 +782,13 @@
             "description": "Edit the pose of 3D models in the WebUI, and generate Openpose/Depth/Normal/Canny maps for ControlNet.",
             "added": "2023-03-16",
             "tags": ["tab"]
+        },
+        {
+            "name": "ModelScope text2video",
+            "url": "https://github.com/deforum-art/sd-webui-modelscope-text2video.git",
+            "description": "Implementation of ModelScope text2video using only Auto1111 webui dependencies.",
+            "added": "2023-03-19",
+            "tags": ["tab", "animation"]
         },
         {
             "name": "zh_CN Localization",


### PR DESCRIPTION
WIP extension here https://github.com/deforum-art/sd-webui-modelscope-text2video

Lightweight and uses only preexisting WebUI packages and dependencies. 6-8 gbs of VRAM should be enough to run as it unloads the StableDiffusion model while it's running