### PR TITLE
Added Discord RPC ext to the list - Update index.json

### DIFF
--- a/index.json
+++ b/index.json
@@ -21,6 +21,13 @@
     },
     "extensions": [
         {
+            "name": "Discord - Dynamic Rich Presence",
+            "url": "https://github.com/davehornik/sd-discord-rich_presence/.git",
+            "description": "Will show your current sd model selected. Also showing if you are idle, or generating something - in that case, total image/s being generated.",
+            "added": "2023-04-04",
+            "tags": ["online","script"]
+        },
+        {
             "name": "Negative Prompt Weight",
             "url": "https://github.com/muerrilla/stable-diffusion-NPW",
             "description": "Allows users to set a global weight for the negative prompt.",


### PR DESCRIPTION
https://github.com/davehornik/sd-discord-rich_presence/

Will show your current sd model selected. Also showing if you are idle, or generating something - in that case, total image/s being generated.