### PR TITLE
add feed extension

### DIFF
--- a/index.json
+++ b/index.json
@@ -978,6 +978,13 @@
             "description": "Old unmaintained localizations that used to be a part of main repository",
             "added": "2022-11-08",
             "tags": ["localization"]
+        },
+        {
+            "name": "WebUI Feed Extension",
+            "url": "https://github.com/todhm/sd_feed.git",
+            "description": "Share your images with the community and receive reputation based on the feedback you receive from other",
+            "added": "2023-04-13",
+            "tags": ["online", "tab"]
         }
     ]
 }


### PR DESCRIPTION
Hello!
The reason why Feed extension is necessary for Web UI is as follows.

I have been using Web UI since January. In Korea, there is a community called “Arca.live” where AI images are actively shared. I discovered a unique user loop:

1.Browse AI images in the community.
2.Find AI images you want to recreate in the community.
3.Create your own image by referring to the parameters of the image you want to recreate in Web UI.
4.Show off well-made images in the community.

I believe that the value of AI images lies in browsing, recreating, and showing off.
To access this community directly within Web UI, I developed a Feed extension, which requires using an external server to save images.

Web UI is a creation tool, but if community features are added, it would be a great help in building the user loop or ecosystem I mentioned earlier. Image producers can gain reputation and potentially generate revenue, while image consumers can easily browse images and use them as inputs for the Web UI tool.

