### PR TITLE
Add mov2mov extension

### DIFF
--- a/index.json
+++ b/index.json
@@ -889,6 +889,13 @@
             "tags": ["tab", "animation"]
         },
         {
+            "name": "mov2mov",
+            "url": "https://github.com/DavG25/sd-webui-mov2mov.git",
+            "description": "Convert videos to AI-generated videos using Stable Diffusion with automatic frame-by-frame processing. Supports MODNet and ControlNet.",
+            "added": "2023-04-29",
+            "tags": ["tab", "animation"]
+        },
+        {
             "name": "zh_CN Localization",
             "url": "https://github.com/dtlnor/stable-diffusion-webui-localization-zh_CN",
             "description": "Simplified Chinese localization, recommend using with Bilingual Localization.",


### PR DESCRIPTION
This extension is a [fork](https://github.com/DavG25/sd-webui-mov2mov) of the original [mov2mov](https://github.com/Scholar01/sd-webui-mov2mov), it processes videos frame-by-frame to create a video using Stable Diffusion

<br>

Compared to the original, this fork differs in a few ways:
- It no longer uses the OpenH264 library (imageio is used instead), so users don't have to download the libopenh264 binary and put it in the system files
- UI and scripts are changed to support the latest version of https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/22bcc7be428c94e9408f589966c2040187245d81 while also supporting older versions (such as https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/a9eab236d7e8afa4d6205127904a385b2c43bb24)
- Translated to English
- The necessary models used in MODNet are downloaded automatically

Full changes compared to the origin repo can be seen [here](https://github.com/Scholar01/sd-webui-mov2mov/compare/master...DavG25:sd-webui-mov2mov:master)