### PR TITLE
Add SD Model Organizer

### DIFF
--- a/index.json
+++ b/index.json
@@ -999,6 +999,13 @@
             "description": "Old unmaintained localizations that used to be a part of main repository",
             "added": "2022-11-08",
             "tags": ["localization"]
+        },
+        {
+            "name": "Model Organizer",
+            "url": "https://github.com/alexandersokol/sd-model-organizer",
+            "description": "Extension that allows to store information about different models needed for Stable Diffusion WebUI, add information, description, notes and download them.",
+            "added": "2023-05-05",
+            "tags": ["tab", "UI related"]
         }
     ]
 }

--- a/index.json
+++ b/index.json
@@ -1003,9 +1003,9 @@
         {
             "name": "Model Organizer",
             "url": "https://github.com/alexandersokol/sd-model-organizer.git",
-            "description": "Extension that allows to store information about different models needed for Stable Diffusion WebUI, add information, description, notes and download them.",
+            "description": "Allows to store and manage own model collections, add information, notes, previews, download links of model. Easily download from any external direct link or shared file link from Google Drive. Share own models collection with json file or use remote Firestore database to make it available and synced on several devices.",
             "added": "2023-05-05",
-            "tags": ["tab", "UI related"]
+            "tags": ["tab", "UI related", "online"]
         }
     ]
 }

--- a/index.json
+++ b/index.json
@@ -1002,7 +1002,7 @@
         },
         {
             "name": "Model Organizer",
-            "url": "https://github.com/alexandersokol/sd-model-organizer",
+            "url": "https://github.com/alexandersokol/sd-model-organizer.git",
             "description": "Extension that allows to store information about different models needed for Stable Diffusion WebUI, add information, description, notes and download them.",
             "added": "2023-05-05",
             "tags": ["tab", "UI related"]


### PR DESCRIPTION
Hello!
Just finished creating a new extension and would like to add it to the general index.

The main goal is to add some user-friendly UI to manage information about models, add own notes and download/remove files.

You can find all information in the README file in the repo.
https://github.com/alexandersokol/sd-model-organizer