### PR TITLE
Add Pixel extension

### DIFF
--- a/index.json
+++ b/index.json
@@ -447,6 +447,13 @@
             "added": "2022-12-24",
             "tags": ["editing"]
         },
+	{
+            "name": "Pixel",
+            "url": "https://github.com/Leodotpy/sd-pixel.git",
+            "description": "Quickly and easily perform downscaling, color palette limiting, and other useful pixel art effects through the extras tab.",
+            "added": "2023-05-05",
+            "tags": ["editing", "extras"]
+        },
         {
             "name": "Pixelization",
             "url": "https://github.com/AUTOMATIC1111/stable-diffusion-webui-pixelization.git",


### PR DESCRIPTION
This extension adds various pixel art effects.  Currently supports downscaling, color palette limiting and grayscale effects. No models are required.