### PR TITLE
Please remove the "ads" tag.

### DIFF
--- a/index.json
+++ b/index.json
@@ -1033,7 +1033,7 @@
             "url": "https://github.com/Physton/sd-webui-prompt-all-in-one",
             "description": "Improve the user experience of the prompt/negative prompt input box. It has a more intuitive and powerful input interface that offers features such as automatic translation, history records, and favorites.",
             "added": "2023-05-08",
-            "tags": ["UI related", "prompting", "ads", "online"]
+            "tags": ["UI related", "prompting", "online"]
         }
     ]
 }


### PR DESCRIPTION
The following modifications have been made regarding the previously submitted PR #45:

1. The GitHub button displayed in the extension interface has been removed, and it is hoped that the ads tag can be removed as well.
2. The data storage path has been changed to within the extension directory and added to the git ignore list.
3. Translation support has been added for most languages spoken in the world. However, most of the localized language interfaces have not been done and can only be displayed in English.
4. A simple test has been conducted on all language translations for all translation interfaces, and services that are completely unusable have been removed.

Thank you for your suggestion.