### PR TITLE
Added Model Preset Manager

### DIFF
--- a/index.json
+++ b/index.json
@@ -258,6 +258,13 @@
             "added": "2022-11-01",
             "tags": ["prompting"]
         },
+		{
+            "name": "Model Preset Manager",
+            "url": "https://github.com/rifeWithKaiju/model_preset_manager.git",
+            "description": "Lets you create and apply presets per model for all generation data (e.g. prompt, negative prompt, cfg_scale, resolution, sampler, clip skip, steps, etc). Also automatically fetches model trigger words and thumbnails from Civitai.",
+            "added": "2023-15-05",
+            "tags": ["online", "prompting", "tab"]
+        },
         {
             "name": "Unprompted",
             "url": "https://github.com/ThereforeGames/unprompted.git",
@@ -1019,13 +1026,6 @@
             "url": "https://github.com/alexandersokol/sd-model-organizer.git",
             "description": "Allows to store and manage own model collections, add information, notes, previews, download links of model. Easily download from any external direct link or shared file link from Google Drive. Share own models collection with json file or use remote Firestore database to make it available and synced on several devices.",
             "added": "2023-05-05",
-            "tags": ["tab", "UI related", "online"]
-        },
-        {
-            "name": "Stable Diffusion Webui Civitai Helper",
-            "url": "https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper.git",
-            "description": "Download or populate models with metadata and preview image from civitai.com",
-            "added": "2023-05-16",
             "tags": ["tab", "UI related", "online"]
         },
         {

--- a/index.json
+++ b/index.json
@@ -1025,7 +1025,7 @@
             "name": "Model Preset Manager",
             "url": "https://github.com/rifeWithKaiju/model_preset_manager.git",
             "description": "Lets you create and apply presets per model for all generation data (e.g. prompt, negative prompt, cfg_scale, resolution, sampler, clip skip, steps, etc). Also automatically fetches model trigger words and thumbnails from Civitai.",
-            "added": "2023-15-05",
+            "added": "2023-05-15",
             "tags": ["online", "prompting", "tab"]
         },
         {

--- a/index.json
+++ b/index.json
@@ -258,13 +258,6 @@
             "added": "2022-11-01",
             "tags": ["prompting"]
         },
-		{
-            "name": "Model Preset Manager",
-            "url": "https://github.com/rifeWithKaiju/model_preset_manager.git",
-            "description": "Lets you create and apply presets per model for all generation data (e.g. prompt, negative prompt, cfg_scale, resolution, sampler, clip skip, steps, etc). Also automatically fetches model trigger words and thumbnails from Civitai.",
-            "added": "2023-15-05",
-            "tags": ["online", "prompting", "tab"]
-        },
         {
             "name": "Unprompted",
             "url": "https://github.com/ThereforeGames/unprompted.git",
@@ -1026,6 +1019,20 @@
             "url": "https://github.com/alexandersokol/sd-model-organizer.git",
             "description": "Allows to store and manage own model collections, add information, notes, previews, download links of model. Easily download from any external direct link or shared file link from Google Drive. Share own models collection with json file or use remote Firestore database to make it available and synced on several devices.",
             "added": "2023-05-05",
+            "tags": ["tab", "UI related", "online"]
+        },
+		{
+            "name": "Model Preset Manager",
+            "url": "https://github.com/rifeWithKaiju/model_preset_manager.git",
+            "description": "Lets you create and apply presets per model for all generation data (e.g. prompt, negative prompt, cfg_scale, resolution, sampler, clip skip, steps, etc). Also automatically fetches model trigger words and thumbnails from Civitai.",
+            "added": "2023-15-05",
+            "tags": ["online", "prompting", "tab"]
+        },
+        {
+            "name": "Stable Diffusion Webui Civitai Helper",
+            "url": "https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper.git",
+            "description": "Download or populate models with metadata and preview image from civitai.com",
+            "added": "2023-05-16",
             "tags": ["tab", "UI related", "online"]
         },
         {


### PR DESCRIPTION
https://github.com/rifeWithKaiju/model_preset_manager

Lets you create and apply presets per model for all generation data (e.g. prompt, negative prompt, cfg_scale, resolution, sampler, clip skip, steps, etc). Also automatically fetches model trigger words and thumbnails from Civitai.
