### PR TITLE
Added Web UI client queue

### DIFF
--- a/index.json
+++ b/index.json
@@ -1104,6 +1104,13 @@
             "description": "WebUI extension for StableSR - a powerful upscaler for both realistic and anime images",
             "added": "2023-05-22",
             "tags": ["manipulations"]
+        },
+        {
+            "name": "Web UI client queue",
+            "url": "https://github.com/Kryptortio/SDAtom-WebUi-client-queue-ext.git",
+            "description": "Adds a queue function to the web ui that processes a set of settings one or more times, it can then load a different set of settings and so on.",
+            "added": "2023-05-23",
+            "tags": ["script", "UI related", "prompting"]
         }
     ]
 }


### PR DESCRIPTION
This extension is a queue system for the web ui, it's strictly client side with everything done in the browser. Everything is mostly done by using the web ui itself to change the settings and generate images. There are [some minor](https://github.com/Kryptortio/SDAtom-WebUi-us#prompt-filter) additional features but mainly it exists to add a queue.

Initially [I made a user script](https://github.com/Kryptortio/SDAtom-WebUi-us) (main repo) for myself to save time by not having to wait for the prompts to finish before adding the next one. However since people [seemed](https://www.reddit.com/r/StableDiffusion/comments/zq0wl9/i_made_a_queue_system_for_automatic1111s_stable/) to [like it](https://www.reddit.com/r/StableDiffusion/comments/11boc0j/i_posted_a_couple_of_month_ago_about_a_queue/) I've also made [an extension version](https://github.com/Kryptortio/SDAtom-WebUi-client-queue-ext) that just contains the user script (making it easy to add fixes to both repos).