### PR TITLE
Add AWS Extension for Stable Diffusion

### DIFF
--- a/index.json
+++ b/index.json
@@ -24,8 +24,8 @@
             "name": "Stable Diffusion AWS Extension",
             "url": "https://github.com/awslabs/stable-diffusion-aws-extension.git",
             "description": "Allow user to migrate existing workloads including ckpt merge, model training, model inferencing onto AWS",
-            "added": "2023-05-01",
-            "tags": ["tab", "training"]
+            "added": "2023-06-01",
+            "tags": ["tab", "training", "online"]
         },
         {
             "name": "Aesthetic Gradients",

--- a/index.json
+++ b/index.json
@@ -21,6 +21,13 @@
     },
     "extensions": [
         {
+            "name": "Stable Diffusion AWS Extension",
+            "url": "https://github.com/awslabs/stable-diffusion-aws-extension.git",
+            "description": "Allow user to migrate existing workloads including ckpt merge, model training, model inferencing onto AWS",
+            "added": "2023-05-01",
+            "tags": ["tab", "training"]
+        },
+        {
             "name": "Aesthetic Gradients",
             "url": "https://github.com/AUTOMATIC1111/stable-diffusion-webui-aesthetic-gradients.git",
             "description": "Allows training an embedding from one or few pictures, specifically meant for applying styles. Also, allows use of these specific embeddings to generated images.",


### PR DESCRIPTION
This is a WebUI extension to help user migrate existing workload (inference, train, ckpt merge etc.) from local server or standalone server to AWS Cloud.