### PR TITLE
add neutral prompt

### DIFF
--- a/index.json
+++ b/index.json
@@ -513,7 +513,7 @@
         {
             "name": "Neutral Prompt",
             "url": "https://github.com/ljleb/sd-webui-neutral-prompt.git",
-            "description": "Incorporates new keywords for manipulating noise blending and prompt interactions. Allows for organizing prompts in a hierarchical manner instead of a flat list.",
+            "description": "Adds new keywords for manipulating noise blending and prompt interactions. Allows for organizing prompts in a hierarchical manner instead of a flat list.",
             "added": "2023-05-28",
             "tags": ["manipulations"]
         },

--- a/index.json
+++ b/index.json
@@ -511,6 +511,13 @@
             "tags": ["manipulations"]
         },
         {
+            "name": "Neutral Prompt",
+            "url": "https://github.com/ljleb/sd-webui-neutral-prompt.git",
+            "description": "Incorporates new keywords for manipulating noise blending and prompt interactions. Allows for organizing prompts in a hierarchical manner instead of a flat list.",
+            "added": "2023-05-28",
+            "tags": ["manipulations"]
+        },
+        {
             "name": "Dynamic Thresholding",
             "url": "https://github.com/mcmonkeyprojects/sd-dynamic-thresholding.git",
             "description": "Adds customizable dynamic thresholding to allow high CFG Scale values without the burning / 'pop art' effect.",


### PR DESCRIPTION
This extension currently adds 2 new prompt keywords and allows to combine composable diffusion prompts in a tree instead of just a flat list. It also adds a CFG rescale slider, which will be removed as soon as the webui introduces its own.

https://github.com/ljleb/sd-webui-neutral-prompt