### PR TITLE
Update url to composable LoRA

### DIFF
--- a/index.json
+++ b/index.json
@@ -555,8 +555,7 @@
         {
             "name": "Latent Couple",
             "url": "https://github.com/ashen-sensored/stable-diffusion-webui-two-shot.git",
-            "description": "An extension of the built-in 
-		Diffusion, allows you to determine the region of the latent space that reflects your subprompts. Note: New maintainer, uninstall prev. ext if needed.",
+            "description": "An extension of the built-in Composable Diffusion, allows you to determine the region of the latent space that reflects your subprompts. Note: New maintainer, uninstall prev. ext if needed.",
             "added": "2023-02-18",
             "tags": ["manipulations"]
         },

--- a/index.json
+++ b/index.json
@@ -555,15 +555,16 @@
         {
             "name": "Latent Couple",
             "url": "https://github.com/ashen-sensored/stable-diffusion-webui-two-shot.git",
-            "description": "An extension of the built-in Composable Diffusion, allows you to determine the region of the latent space that reflects your subprompts. Note: New maintainer, uninstall prev. ext if needed.",
+            "description": "An extension of the built-in 
+		Diffusion, allows you to determine the region of the latent space that reflects your subprompts. Note: New maintainer, uninstall prev. ext if needed.",
             "added": "2023-02-18",
             "tags": ["manipulations"]
         },
         {
             "name": "Composable LoRA",
-            "url": "https://github.com/opparco/stable-diffusion-webui-composable-lora.git",
+            "url": "https://github.com/a2569875/stable-diffusion-webui-composable-lora.git",
             "description": "Enables using AND keyword(composable diffusion) to limit LoRAs to subprompts. Useful when paired with Latent Couple extension.",
-            "added": "2023-02-25",
+            "added": "2023-05-30",
             "tags": ["manipulations"]
         },
         {

--- a/index.json
+++ b/index.json
@@ -563,7 +563,7 @@
             "name": "Composable LoRA",
             "url": "https://github.com/a2569875/stable-diffusion-webui-composable-lora.git",
             "description": "Enables using AND keyword(composable diffusion) to limit LoRAs to subprompts. Useful when paired with Latent Couple extension.",
-            "added": "2023-05-30",
+            "added": "2023-06-23",
             "tags": ["manipulations"]
         },
         {


### PR DESCRIPTION
The original repo is broken and no longer maintained. I tested this version and it is working as expected in A1111.