### PR TITLE
Change sd-webui-faceswap to sd-webui-roop. The first project is disco…

### DIFF
--- a/index.json
+++ b/index.json
@@ -1232,10 +1232,10 @@
             "tags": ["script", "tab"]
         },
         {
-            "name": "sd-webui-faceswap",
-            "url": "https://github.com/Ynn/sd-webui-faceswap",
+            "name": "sd-webui-roop",
+            "url": "https://github.com/s0md3v/sd-webui-roop",
             "description": "Enable face swapping with reference image.",
-            "added": "2023-06-09",
+            "added": "2023-06-18",
             "tags": ["editing","manipulations"]
         },
         {


### PR DESCRIPTION
I am not maintaining faceswap anymore. The project was kindly taken over by the author of roop, on which it was based. I made the name changes and indicated on my repo that the code had migrated.