### PR TITLE
add sd-webui-pixelart

### DIFF
--- a/extensions/sd-webui-pixelart.json
+++ b/extensions/sd-webui-pixelart.json
@@ -1,0 +1,10 @@
+{
+    "name": "Pixel art",
+    "url": "https://github.com/mrreplicart/sd-webui-pixelart.git",
+    "description": "Extension that provides basic functionality for pixel art: downscaling, palette limiting, grayscale, black&white, ability to change image colors with custom color palette",
+    "tags": [
+        "script",
+        "editing",
+        "extras"
+    ]
+}


### PR DESCRIPTION
Added extension for pixel art.
It includes script for txt2img/img2img tabs as well as additional section in extras.

It don't use models to create pixel art images like [pixelization extension](https://github.com/AUTOMATIC1111/stable-diffusion-webui-pixelization) and have more functionality than [sd-pixel](https://github.com/Leodotpy/sd-pixel), although both extensions are good.

![color_tab](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/assets/137555918/dd99eb2c-5913-44d0-8af9-ca065062bd55)