### PR TITLE
Create civitai-shortcut.json

### DIFF
--- a/extensions/civitai-shortcut.json
+++ b/extensions/civitai-shortcut.json
@@ -1,0 +1,9 @@
+{
+    "name": "Civitai Shortcut",
+    "url": "https://github.com/sunnyark/civitai-shortcut.git",
+    "description": "This extension allows you to register the models available on civitai as favorites (shortcuts) in sdui, and then you can download the models using the registered shortcuts when needed.",
+    "tags": [
+        "models",
+        "extras"
+    ]
+}


### PR DESCRIPTION
This extension allows you to register the models available on civitai as favorites (shortcuts) in sdui, and then you can download the models using the registered shortcuts when needed.