### PR TITLE
Change extensions forks to original extensions added dates

### DIFF
--- a/extensions/mine-diffusion.json
+++ b/extensions/mine-diffusion.json
@@ -4,7 +4,6 @@
     "description": "This extension converts images into blocks and creates schematics for easy importing into Minecraft using the Litematica mod.",
     "added": "2023-02-11",
     "tags": [
-        "tab",
-        "online"
+        "tab"
     ]
 }

--- a/extensions/sd-webui-roop.json
+++ b/extensions/sd-webui-roop.json
@@ -2,7 +2,7 @@
     "name": "sd-webui-roop",
     "url": "https://github.com/s0md3v/sd-webui-roop",
     "description": "Enable face swapping with reference image.",
-    "added": "2023-06-18",
+    "added": "2023-06-09",
     "tags": [
         "editing",
         "manipulations"

--- a/extensions/stable-diffusion-webui-composable-lora.json
+++ b/extensions/stable-diffusion-webui-composable-lora.json
@@ -2,7 +2,7 @@
     "name": "Composable LoRA",
     "url": "https://github.com/a2569875/stable-diffusion-webui-composable-lora.git",
     "description": "Enables using AND keyword(composable diffusion) to limit LoRAs to subprompts. Useful when paired with Latent Couple extension.",
-    "added": "2023-06-23",
+    "added": "2023-02-25",
     "tags": [
         "manipulations"
     ]


### PR DESCRIPTION
Some of the new maintainer forks changed the date the extension was added. This would keep the extension listed in chronological format.

Also removed the online tag from mine-diffusion.