### PR TITLE
Create Simplified_Chinese_Language_Pack

### DIFF
--- a/extensions/Simplified_Chinese_Language_Pack.json
+++ b/extensions/Simplified_Chinese_Language_Pack.json
@@ -1,0 +1,9 @@
+{
+    "name": "Simplified Chinese Language Pack",
+    "url": "https://github.com/StormyOrange/SD-WebUI-Localization_ZH_CN.git",
+    "description": "Display WebUI interface in Simplified Chinese",
+    "tags": [
+        "UI related"
+    ],
+    "added": "2023-07-24"
+}


### PR DESCRIPTION
Simplified Chinese translation of all WebUI texts since v1.0.0-pre, and corrected unreasonable translations by dtlnor. Also translated a large number of extensions by other authors into simplified Chinese, with a total of 6000+ words translated.