### PR TITLE
Create sd-webui-fabric.json

### DIFF
--- a/extensions/sd-webui-fabric.json
+++ b/extensions/sd-webui-fabric.json
@@ -1,0 +1,9 @@
+{
+    "name": "FABRIC",
+    "url": "https://github.com/dvruette/sd-webui-fabric.git",
+    "description": "Personalizing Diffusion Models with Iterative Feedback, a training-free approach that conditions the diffusion process on a set of feedback images",
+    "tags": [
+        "script",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
Hi @dvruette we received a [request](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/issues/172) to add your extension to index https://github.com/dvruette/sd-webui-fabric to the extension index
before we add it we would like to confirm with you

are you okay with it being listed like this
```json
{
    "name": "FABRIC",
    "url": "https://github.com/dvruette/sd-webui-fabric.git",
    "description": "Personalizing Diffusion Models with Iterative Feedback, a training-free approach that conditions the diffusion process on a set of feedback images",
    "tags": [
        "script",
        "manipulations"
    ]
}
```
if you like to make any changes on how it's listed please leave a comment or make a new PR

scheduled to be added after a week if we did not receive any negative response from you

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
