### PR TITLE
Create sdwebui-leave-warining.json

### DIFF
--- a/extensions/sdwebui-leave-warining.json
+++ b/extensions/sdwebui-leave-warining.json
@@ -1,0 +1,8 @@
+{
+    "name": "sdwebui-leave-warining",
+    "url": "https://github.com/w-e-w/sdwebui-leave-warining.git",
+    "description": "Adds a pop-up warning when you try to \"leave\" or \"reload\" the web page",
+    "tags": [
+        "UI related"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/w-e-w/sdwebui-leave-warining.git
Adds a pop-up warning when you try to "leave" or "reload" the web page

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
