### PR TITLE
Update Stable-Diffusion-Webui-Civitai-Helper.json

### DIFF
--- a/extensions/Stable-Diffusion-Webui-Civitai-Helper.json
+++ b/extensions/Stable-Diffusion-Webui-Civitai-Helper.json
@@ -1,6 +1,6 @@
 {
     "name": "Stable Diffusion Webui Civitai Helper",
-    "url": "https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper.git",
+    "url": "https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper.git",
     "description": "Download or populate models with metadata and preview image from civitai.com",
     "added": "2023-05-16",
     "tags": [


### PR DESCRIPTION
The current version of Stable-Diffusion-Webui-Civitai-Helper has been broken since v1.5.0 of Stable Diffusion-webui. I am wiling to maintain a currently working version.

## Info 
Since the original extension stopped working properly, I have been updating it to maintain compatibility, along with adding additional functionality.
https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper

## Checklist:
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
