### PR TITLE
Add Masonry Gallery Extension

### DIFF
--- a/extensions/sd-masonry.json
+++ b/extensions/sd-masonry.json
@@ -1,0 +1,11 @@
+{
+    "name": "SD Masonry Gallery",
+    "url": "https://github.com/bit9labs/sd-masonry.git",
+    "description": "An images tab to display local images in a compact masonry gallery.",
+    "tags": [
+        "script",
+        "tab",
+        "UI related",
+        "online"
+    ]
+}


### PR DESCRIPTION
## Info 
A pull request to add SD Masonry Gallery (https://github.com/bit9labs/sd-masonry)

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [ ] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [ ] The description is written in English.
- [ ] The `index.json` and `extension_template.json` have not been modified.
- [ ] The `entry` is placed in the `extensions` directory with the `.json` file extension.
