### PR TITLE
Add sd-webui-civbrowser.json

### DIFF
--- a/extensions/sd-webui-civbrowser.json
+++ b/extensions/sd-webui-civbrowser.json
@@ -1,0 +1,10 @@
+{
+    "name": "CivBrowser",
+    "url": "https://github.com/SignalFlagZ/sd-webui-civbrowser.git",
+    "description": "Extension to search and download Civitai models in multiple tabs. Save model information. Send sample infotext to txt2img.",
+    "tags": [
+        "script",
+        "tab",
+        "online"
+    ]
+}


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->
https://github.com/SignalFlagZ/sd-webui-civbrowser
Extension to search and download Civitai models in multiple tabs. Save model information. Send sample infotext to txt2img.
## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
