### PR TITLE
Added Ranbooru

### DIFF
--- a/extensions/sd-webui-ranbooru.json
+++ b/extensions/sd-webui-ranbooru.json
@@ -1,0 +1,11 @@
+{
+    "name": "Ranbooru",
+    "url": "https://github.com/Inzaniak/sd-webui-ranbooru.git",
+    "description": "Get random prompts from different boorus with a lot of creative features to influence the prompts. Works with txt2img and img2img",
+    "tags": [
+        "script",
+        "dropdown",
+        "prompting",
+        "online"
+    ]
+}


### PR DESCRIPTION
## Info 
[https://github.com/Inzaniak/sd-webui-ranbooru](https://github.com/Inzaniak/sd-webui-ranbooru)
Ranbooru is an extension to get prompts from different boorus using their APIs. It also has additional features to dinamically change the prompt.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [ ] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [ ] The description is written in English.
- [ ] The `index.json` and `extension_template.json` have not been modified.
- [ ] The `entry` is placed in the `extensions` directory with the `.json` file extension.
