### PR TITLE
Update sd-civitai-browser-plus name and description

### DIFF
--- a/extensions/sd-civitai-browser-plus.json
+++ b/extensions/sd-civitai-browser-plus.json
@@ -1,7 +1,7 @@
 {
-    "name": "CivitAI Browser Plus",
+    "name": "CivitAI Browser+",
     "url": "https://github.com/BlafKing/sd-civitai-browser-plus.git",
-    "description": "This extension allows you to browse and download any model from CivitAi without leaving WebUI!",
+    "description": "Extension to access CivitAI via WebUI: download, delete, scan for updates, list installed models, assign tags, and boost downloads with multi-threading.",
     "tags": [
         "script",
         "tab",


### PR DESCRIPTION
## Info 
I've made a small edit to my extension.json which is already added to the database.

I've changed the name (to match the naming I use on my repo) and I've changed the description since I've added quite a lot of features since the first merge request of the extension.

(Haven't changed the index.json with the new naming/description, since it was requested to not do so)

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
