### PR TITLE
add uddetailer

### DIFF
--- a/extensions/uddetailer.json
+++ b/extensions/uddetailer.json
@@ -1,0 +1,9 @@
+{
+    "name": "µ Detection Detailer",
+    "url": "https://github.com/wkpark/uddetailer.git",
+    "description": "µ Detection Detailer. Fork of ddetailer. Supports bbox/segment object detection, auto-mask and inpainting using mmdetection, mediapipe and ultralytics. also supports ControlNet.",
+    "tags": [
+        "editing",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
## Info

https://github.com/wkpark/uddetailer

µ Detection Detailer, a ddetailer fork.

Supports bbox/segment object detection, auto-mask and inpainting using mmdetection, mediapipe and ultralytics. also supports ControlNet.
 * support mmdet v2 and v3
 * mmyolo model supported (with mmdet v3)
 * optionally support mediapipe and ultralytics models
 * ControlNet support integrated.
 * support load/save presets.
 * support importing ADetailer/DDetailer infotext settings.


## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
