### PR TITLE
Add sd-webui-breadcrumbs extension

### DIFF
--- a/extensions/sd-webui-breadcrumbs.json
+++ b/extensions/sd-webui-breadcrumbs.json
@@ -1,0 +1,8 @@
+{
+    "name": "sd-webui-breadcrumbs",
+    "url": "https://github.com/ThereforeGames/sd-webui-breadcrumbs.git",
+    "description": "Adds a breadcrumb trail and makes improvements to the Quicksettings menu.",
+    "tags": [
+        "UI related"
+    ]
+}


### PR DESCRIPTION
## Info 
Repo: https://github.com/ThereforeGames/sd-webui-breadcrumbs

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
