### PR TITLE
Dynamic Prompts add online tag

### DIFF
--- a/extensions/sd-dynamic-prompts.json
+++ b/extensions/sd-dynamic-prompts.json
@@ -4,6 +4,7 @@
     "description": "Implements an expressive template language for random or combinatorial prompt generation along with features to support deep wildcard directory structures.",
     "added": "2022-11-01",
     "tags": [
-        "prompting"
+        "prompting",
+        "online"
     ]
 }


### PR DESCRIPTION
@adieyal
bese on issue report https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/issues/245

I've confirmed that [`I'm feeling lucky` future of Dynamic Prompts](https://github.com/adieyal/sd-dynamic-prompts#im-feeling-lucky) calls to external API, and I agree with #245 assessment this extension needs an online tag

since it's not the core functionality of the extension it can have the online tag removed if
there's no chance of the user accidentally using it without they beeing fully aware that a external API will be used
as far as I can see the only indication currently is in the documentation, I believe that is insufficient, there should also be some sort of indication in the UI