### PR TITLE
redirect embedding-inspector

### DIFF
--- a/extensions/embedding-inspector.json
+++ b/extensions/embedding-inspector.json
@@ -1,6 +1,6 @@
 {
     "name": "embedding-inspector",
-    "url": "https://github.com/tkalayci71/embedding-inspector.git",
+    "url": "https://github.com/w-e-w/embedding-inspector.git",
     "description": "Inspect any token(a word) or Textual-Inversion embeddings and find out which embeddings are similar. You can mix, modify, or create the embeddings in seconds.",
     "added": "2022-12-06",
     "tags": [


### PR DESCRIPTION
redirect https://github.com/tkalayci71/embedding-inspector to https://github.com/w-e-w/embedding-inspector

---

For unknown reason the the author of this extension [@tkalayci71](https://github.com/tkalayci71) has deleted his GitHub account
This is a re-uploaded clone
original URL https://github.com/tkalayci71/embedding-inspector Since the code is licensed under [Unlicense](https://github.com/w-e-w/embedding-inspector/blob/main/LICENSE), I have re-uploaded the repository using a found fork on GitHub.

I take no credit and was not involved in development of this extension and I have no plans to maintaining it.

If someone wished to maintain this extension please get in contact.