### PR TITLE
Add sd-webui-lama-cleaner-masked-content

### DIFF
--- a/extensions/sd-webui-lama-cleaner-masked-content.json
+++ b/extensions/sd-webui-lama-cleaner-masked-content.json
@@ -1,7 +1,7 @@
 {
     "name": "Lama cleaner as masked content",
     "url": "https://github.com/light-and-ray/sd-webui-lama-cleaner-masked-content.git",
-    "description": "Use lama cleaner preprocessor from controlnet inside Inpaint tab. Reuires sd-webui-controlnet",
+    "description": "Use lama cleaner preprocessor from controlnet inside Inpaint tab. Reuires sd-webui-controlnet. Can be useful with removing objects in inpaint tab",
     "tags": [
         "script",
         "manipulations"

--- a/extensions/sd-webui-lama-cleaner-masked-content.json
+++ b/extensions/sd-webui-lama-cleaner-masked-content.json
@@ -1,0 +1,9 @@
+{
+    "name": "Lama cleaner as masked content",
+    "url": "https://github.com/light-and-ray/sd-webui-lama-cleaner-masked-content.git",
+    "description": "Use lama cleaner preprocessor from controlnet inside Inpaint tab. Reuires sd-webui-controlnet",
+    "tags": [
+        "script",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-lama-cleaner-masked-content
Use lama cleaner preprocessor from controlnet inside Inpaint tab. Reuires sd-webui-controlnet

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
