### PR TITLE
add sd-webui-video-extras-tab

### DIFF
--- a/extensions/sd-webui-video-extras-tab.json
+++ b/extensions/sd-webui-video-extras-tab.json
@@ -1,0 +1,11 @@
+{
+    "name": "Video in Extras tab",
+    "url": "https://github.com/light-and-ray/sd-webui-video-extras-tab.git",
+    "description": "This extension is needed to process video frame by frame inside extras tab.",
+    "tags": [
+        "tab",
+        "editing",
+        "animation",
+        "extras"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-video-extras-tab
This extension is needed to process video frame by frame inside extras tab.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
