### PR TITLE
sd-webui-inpaintconverter

### DIFF
--- a/extensions/sd-webui-inpaintconverter.json
+++ b/extensions/sd-webui-inpaintconverter.json
@@ -1,0 +1,8 @@
+{
+    "name": "Inpaint Model Converter",
+    "url": "https://github.com/groinge/sd-webui-inpaintconverter.git",
+    "description": "Automatically converts any SD v1.5 checkpoint in to a temporary inpainting model",
+    "tags": [
+        "models"
+    ]
+}


### PR DESCRIPTION
## Info 
[https://github.com/groinge/sd-webui-inpaintconverter](https://github.com/groinge/sd-webui-inpaintconverter)

Simple extension that removes the need for discrete inpainting models. 

The extension downloads this model when first enabled. Which is a unet from the merge v1.5inpainting - v1.5
https://huggingface.co/groinge/inpaintdifferencemerge/commits/main/V1_5inpaintdifference.safetensors

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
