### PR TITLE
add ControlNet Preprocessor in extras tab

### DIFF
--- a/extensions/sd-webui-cn-in-extras-tab.json
+++ b/extensions/sd-webui-cn-in-extras-tab.json
@@ -1,0 +1,11 @@
+{
+    "name": "ControlNet Preprocessor in extras tab",
+    "url": "https://github.com/light-and-ray/sd-webui-cn-in-extras-tab.git",
+    "description": "Adds controlnet preprocessing feature into Extras tab",
+    "tags": [
+        "script",
+        "dropdown",
+        "editing",
+        "extras"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-cn-in-extras-tab
ControlNet Preprocessor in extras tab

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
