### PR TITLE
Fork of StylePile fixing Gradio deprecated syntax

### DIFF
--- a/extensions/StylePile-Gradio-Patch
+++ b/extensions/StylePile-Gradio-Patch
@@ -1,0 +1,9 @@
+{
+    "name": "StylePile",
+    "url": "https://github.com/samfisherirl/StylePile-Gradio-Patch.git",
+    "description": "Fork of StylePile with updated syntax for Gradio to ensure future compatibility. ",
+    "added": "2024-02-13",
+    "tags": [
+        "prompting"
+    ]
+}

--- a/extensions/StylePile-Gradio-Patch.json
+++ b/extensions/StylePile-Gradio-Patch.json
@@ -1,5 +1,5 @@
 {
-    "name": "StylePile",
+    "name": "StylePile-Gradio-Patch",
     "url": "https://github.com/samfisherirl/StylePile-Gradio-Patch.git",
     "description": "Fork of StylePile with updated syntax for Gradio to ensure future compatibility. ",
     "added": "2024-02-13",


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [ ] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [ ] The description is written in English.
- [ ] The `index.json` and `extension_template.json` have not been modified.
- [ ] The `entry` is placed in the `extensions` directory with the `.json` file extension.


```batch
To create a public link, set `share=True` in `launch()`.
WARNING:py.warnings:D:\sd-webuiDEV\stable-diffusion-webui-dev\extensions\StylePile\scripts\StylePile.py:412: GradioDeprecationWarning: The `style` method is deprecated. Please set these arguments in the constructor instead.
  gr.Gallery(value=ResultDirectionImages, show_label=False).style(

WARNING:py.warnings:D:\sd-webuiDEV\stable-diffusion-webui-dev\extensions\StylePile\scripts\StylePile.py:412: GradioDeprecationWarning: The 'grid' parameter will be deprecated. Please use 'columns' in the constructor instead.
  gr.Gallery(value=ResultDirectionImages, show_label=False).style(
```

after waiting a number of months for the original creator to respond to outreach, I've made the adjustments to the code myself. The above warnings were present ~1 year ago on initial merge. I have not been able to get in contact with them during that time. 

the small adjustments to line 412-425 of StylePile.py satisfies the Gradio deprecated syntax issues and works as expected. 