### PR TITLE
Added SD Lora Tagger to extensions

### DIFF
--- a/extensions/SD-Lora-Tagger.json
+++ b/extensions/SD-Lora-Tagger.json
@@ -1,0 +1,11 @@
+{
+    "name": "SD Lora Tagger",
+    "url": "https://github.com/corbin-hayden13/SD-Lora-Tagger.git",
+    "description": "Enables searching extra networks (Lycos, Loras, Embeddings, Checkpoints, Hypernetworks) through tags that can be edited in the added Tag Editor",
+    "tags": [
+        "script",
+        "UI related",
+        "tab",
+        "online"
+    ]
+}


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->
Repo URL [here](https://github.com/corbin-hayden13/SD-Lora-Tagger.git).
This extension is being actively maintained and developed.
I wasn't sure whether or not to tag the extension with "online" because there's a feature to make api requests to Civitai but this is triggered by a button click and not part of the main function of the extension, but I tagged it anyways with "online" to be safe.
Thanks for your consideration!

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
