### PR TITLE
Update and rename sd-webui-tinycards.json to sd-webui-cardmaster.json

### DIFF
--- a/extensions/sd-webui-cardmaster.json
+++ b/extensions/sd-webui-cardmaster.json
@@ -1,7 +1,7 @@
 {
     "name": "Card Master",
-    "url": "https://github.com/SenshiSentou/sd-webui-tinycards.git",
-    "description": "Adds powerful tools to the \"extra network\" cards (esp. LoRAs), including detail views, easy application of activation texts to the negative prompt, partial application of activation texts that contain multiple sections, and automatic prompt cleanup when removing a LoRA.",
+    "url": "https://github.com/SenshiSentou/sd-webui-cardmaster.git",
+    "description": "Adds powerful tools to the \"extra network\" cards (esp. LoRAs), including detail views, easy application of activation texts to the negative prompt, partial application of activation texts that contain multiple sections, and automatic prompt cleanup when removing a LoRA. This extension was previously known as tinycards. Please remove the old version if you still have it installed.",
     "tags": [
         "UI related"
     ],

--- a/extensions/sd-webui-cardmaster.json
+++ b/extensions/sd-webui-cardmaster.json
@@ -1,0 +1,9 @@
+{
+    "name": "Card Master",
+    "url": "https://github.com/SenshiSentou/sd-webui-tinycards.git",
+    "description": "Adds powerful tools to the \"extra network\" cards (esp. LoRAs), including detail views, easy application of activation texts to the negative prompt, partial application of activation texts that contain multiple sections, and automatic prompt cleanup when removing a LoRA.",
+    "tags": [
+        "UI related"
+    ],
+    "added": "2023-11-25"
+}

--- a/extensions/sd-webui-tinycards.json
+++ b/extensions/sd-webui-tinycards.json
@@ -1,9 +1,0 @@
-{
-    "name": "Tiny Cards",
-    "url": "https://github.com/SenshiSentou/sd-webui-tinycards.git",
-    "description": "Adds a simple zoom slider with grow-on-hover to the \"extra network\" cards (hypernetworks, TIs, checkpoints, and LoRAs)",
-    "tags": [
-        "UI related"
-    ],
-    "added": "2023-11-25"
-}


### PR DESCRIPTION
## Info 
Kept the git URL the same as it redirects. This will (hopefully?) allow users to simply update their existing Tiny Cards extension. New URL is https://github.com/SenshiSentou/sd-webui-cardmaster

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
