### PR TITLE
add cli-interruption

### DIFF
--- a/extensions/sd-webui-cli-interruption.json
+++ b/extensions/sd-webui-cli-interruption.json
@@ -1,0 +1,7 @@
+{
+    "name": "cli-interruption",
+    "url": "https://github.com/light-and-ray/sd-webui-cli-interruption.git",
+    "description": "Interrupt generation on SIGINT signal (Ctrl+C), instead of closing the server.",
+    "tags": [
+    ]
+}


### PR DESCRIPTION
## Info 
Interrupt generation on SIGINT signal (Ctrl+C), instead of closing the server.
https://github.com/light-and-ray/sd-webui-cli-interruption

Suddenly it was very easy and good-looking to add this feature like an extension instead of PR. Really better

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
