### PR TITLE
replacer add script tag

### DIFF
--- a/extensions/Replacer.json
+++ b/extensions/Replacer.json
@@ -5,7 +5,8 @@
     "tags": [
         "tab",
         "editing",
-        "animation"
+        "animation",
+        "script"
     ],
     "added": "2023-12-06"
 }


### PR DESCRIPTION
## Info 
I've added txt2img/img2img script in my extension
https://github.com/light-and-ray/sd-webui-replacer/blob/master/docs/usage.md#replacer-script-in-txt2imgimg2img-tabs

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
