### PR TITLE
Rename adetailer

### DIFF
--- a/extensions/adetailer.json
+++ b/extensions/adetailer.json
@@ -1,5 +1,5 @@
 {
-    "name": "!After Detailer",
+    "name": "ADetailer",
     "url": "https://github.com/Bing-su/adetailer.git",
     "description": "Automatic detection, masking and inpainting tool for details",
     "added": "2023-05-12",


### PR DESCRIPTION
## Info 

https://github.com/Bing-su/adetailer

This is to unify the name and make search easier for folks.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
