### PR TITLE
add sd-webui-old-sd-firstpasser

### DIFF
--- a/extensions/sd-webui-old-sd-firstpasser.json
+++ b/extensions/sd-webui-old-sd-firstpasser.json
@@ -1,0 +1,9 @@
+{
+    "name": "Old SD firstpasser",
+    "url": "https://github.com/light-and-ray/sd-webui-old-sd-firstpasser.git",
+    "description": "Firstpass generation with old SD model, Loras, embedding, etc ",
+    "tags": [
+        "script",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
Disappointed in XAdapter paper-scam but wanted to use sd 1.5 character lora in sdxl, I've made this extension

https://github.com/light-and-ray/sd-webui-old-sd-firstpasser.git
Firstpass generation with old SD model, Loras, embedding, etc 

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
