### PR TITLE
update Replacer's description

### DIFF
--- a/extensions/Replacer.json
+++ b/extensions/Replacer.json
@@ -1,7 +1,7 @@
 {
     "name": "Replacer - fast inpaint",
     "url": "https://github.com/light-and-ray/sd-webui-replacer.git",
-    "description": "Adds a tab for fast inpaint image by detection prompt. Requires sd-webui-segment-anything. It also useful for batch inpaint, and inpaint in video with stable diffusion. Or you can just draw your own mask and use powerful hiresfix, or convenient controlnet inpainting",
+    "description": "Adds a tab for fast inpaint image by detection prompt. Requires sd-webui-segment-anything. It also useful for batch inpaint, and inpaint in video with AnimateDiff. Or you can just draw your own mask and use powerful hiresfix, or convenient controlnet fullres inpainting",
     "tags": [
         "tab",
         "editing",


### PR DESCRIPTION
## Info 
It was hard in developing, but the consistency of animatediff worths it 🫠
https://github.com/light-and-ray/sd-webui-replacer/blob/master/docs/video.md

It is not urgent, it needs to have this little pr merged https://github.com/continue-revolution/sd-webui-animatediff/pull/499

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
