### PR TITLE
add readme browser

### DIFF
--- a/extensions/sd-webui-readme-browser.json
+++ b/extensions/sd-webui-readme-browser.json
@@ -1,0 +1,9 @@
+{
+    "name": "Readme browser",
+    "url": "https://github.com/light-and-ray/sd-webui-readme-browser.git",
+    "description": "This extension allows user to view readme files of extensions locally right inside sd-webui",
+    "tags": [
+        "dropdown",
+        "UI related"
+    ]
+}

--- a/extensions/sd-webui-readme-browser.json
+++ b/extensions/sd-webui-readme-browser.json
@@ -1,9 +1,10 @@
 {
     "name": "Readme browser",
     "url": "https://github.com/light-and-ray/sd-webui-readme-browser.git",
-    "description": "This extension allows user to view readme files of extensions locally right inside sd-webui",
+    "description": "This extension allows user to view readme files of extensions locally right inside sd-webui. Online will be used only if readme contains external media and links",
     "tags": [
         "dropdown",
+        "online",
         "UI related"
     ]
 }


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-readme-browser
This extension allows user to view readme files of extensions locally right inside sd-webui

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
