### PR TITLE
Add prompt-from-text-or-tagger, expanded-xyz-plot, clipboard extensions

### DIFF
--- a/extensions/sd-webui-clipboard.json
+++ b/extensions/sd-webui-clipboard.json
@@ -1,0 +1,8 @@
+{
+    "name": "sd-webui-clipboard",
+    "url": "https://github.com/GiusTex/sd-webui-clipboard.git",
+    "description": "Extension that adds a textfield where to store notes, prompt parts, parameters etc between sessions. Useful if you want to store prompt parts and parameters while testing",
+    "tags": [
+        "script"
+    ]
+}

--- a/extensions/sd-webui-expanded-xyz-plot.json
+++ b/extensions/sd-webui-expanded-xyz-plot.json
@@ -1,0 +1,8 @@
+{
+    "name": "sd-webui-expanded-xyz-plot",
+    "url": "https://github.com/GiusTex/sd-webui-expanded-xyz-plot.git",
+    "description": "Updated version of yspacedevyspacedev Expanded-XY-grid. Adds more features to the standard xyz grid, such as putting multiple parameters in an axis row. Useful if you want to test more than 3 parameters at a time",
+    "tags": [
+        "script"
+    ]
+}

--- a/extensions/sd-webui-prompt-from-text-or-tagger.json
+++ b/extensions/sd-webui-prompt-from-text-or-tagger.json
@@ -1,0 +1,11 @@
+{
+    "name": "sd-webui-prompt-from-text-or-tagger",
+    "url": "https://github.com/GiusTex/sd-webui-prompt-from-text-or-tagger.git",
+    "description": "Like the prompt-from-file-or-textbox script, but with built-in grid-maker and auto-tagger option. Useful to make random images and test prompts based on other images, automatically",
+    "tags": [
+        "script",
+        "prompting",
+        "editing",
+        "query"
+    ]
+}


### PR DESCRIPTION
## Info 
#### Links:
- [prompt-from-text-or-tagger](https://github.com/GiusTex/sd-webui-prompt-from-text-or-tagger). Like the prompt-from-file-or-textbox script, but with built-in grid-maker and auto-tagger option. Useful to make random images and test prompts based on other images, automatically.
- [expanded-xyz-plot](https://github.com/GiusTex/sd-webui-expanded-xyz-plot). Updated version of [yspacedevyspacedev Expanded-XY-grid](https://github.com/yspacedev/Expanded-XY-grid). Adds more features to the standard xyz grid, such as putting multiple parameters in an axis row. Useful if you want to test more than 3 parameters at a time.
- [sd-webui-clipboard](https://github.com/GiusTex/sd-webui-clipboard). Extension that adds a textfield where to store notes, prompt parts, parameters etc between sessions. Useful to store prompt parts and parameters while testing.

I didn't know if it was better to make 3 separate requests or not (in case some didn't go well and prevented the others from being loaded), I hope that a single one is right.

The extensions are maintained.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
