### PR TITLE
add sd-webui-hardware-info-in-metadata

### DIFF
--- a/extensions/sd-webui-hardware-info-in-metadata.json
+++ b/extensions/sd-webui-hardware-info-in-metadata.json
@@ -1,0 +1,8 @@
+{
+    "name": "Hardware Info in metadata",
+    "url": "https://github.com/light-and-ray/sd-webui-hardware-info-in-metadata.git",
+    "description": "Adds hardware info (gpu name, vram, cpu name, ram) and taken time into generated images' metadata",
+    "tags": [
+        "script"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-hardware-info-in-metadata

![Screenshot 2024-05-18 at 01-07-15 Stable Diffusion](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/assets/33491867/91daf61b-af8f-47f8-aacb-fa5297de540b)

It's important for personal history to write such slow gpu info into metadata 🤠

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
