### PR TITLE
Metadata Utils (read/write metadata)

### DIFF
--- a/extensions/metadata_utils.json
+++ b/extensions/metadata_utils.json
@@ -1,10 +1,8 @@
 {
-    "name": "metadata_utils",
+    "name": "Metadata Utils",
     "url": "https://github.com/Tzigo/metadata_utils.git",
-    "description": "metadata utils can read/write metadata from/to .safetensor files",
+    "description": "metadata utils can read/write metadata from/to .safetensor files",
     "tags": [
-        "script",
-        "tab",
-        "dropdown"
+        "tab"
     ]
 }

--- a/extensions/metadata_utils.json
+++ b/extensions/metadata_utils.json
@@ -3,6 +3,7 @@
     "url": "https://github.com/Tzigo/metadata_utils.git",
     "description": "metadata utils can read/write metadata from/to .safetensor files",
     "tags": [
-        "tab"
+        "tab",
+        "models"
     ]
 }

--- a/extensions/metadata_utils.json
+++ b/extensions/metadata_utils.json
@@ -1,6 +1,6 @@
 {
     "name": "metadata_utils",
-    "url": "https://github.com/Tzigo/Metadata_Utils.git",
+    "url": "https://github.com/Tzigo/metadata_utils.git",
     "description": "metadata utils can read/write metadata from/to .safetensor files",
     "tags": [
         "script",

--- a/extensions/metadata_utils.json
+++ b/extensions/metadata_utils.json
@@ -1,0 +1,10 @@
+{
+    "name": "metadata_utils",
+    "url": "https://github.com/Tzigo/Metadata_Utils.git",
+    "description": "metadata utils can read/write metadata from/to .safetensor files",
+    "tags": [
+        "script",
+        "tab",
+        "dropdown"
+    ]
+}


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->
https://github.com/Tzigo/metadata_utils
Metadata Utils is an extension tab for automatic1111, adding a lightweight way of reading/writing metadata from/to .safetensor files

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
