### PR TITLE
Added sd-notes

### DIFF
--- a/extensions/sd-notes-tab.json
+++ b/extensions/sd-notes-tab.json
@@ -1,0 +1,10 @@
+{
+    "name": "Notes Tab",
+    "url": "https://github.com/DocWizard/sd-notes-tab.git",
+    "description": "Adds a simple notes tab.",
+    "tags": [
+        "script",
+        "tab",
+        "UI related",
+    ]
+}


### PR DESCRIPTION
## Info 
Repo url: https://github.com/DocWizard/sd-notes-tab

This is something that I feel should be a base function. I've whipped up an extension which adds a new tab for some basic note taking. Full disclosure, this was done with he help of an LLM. I write technical documentation, not python scripts!

Now, i realize this functionality can be replaced with having notepad open in a separate window... But I like having everything in one place. I thought some others might, too. :)

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
