### PR TITLE
sd webui ar plusplus

### DIFF
--- a/extensions/sd-webui-ar-plusplus.json
+++ b/extensions/sd-webui-ar-plusplus.json
@@ -1,0 +1,8 @@
+{
+    "name": "Aspect Ratio and Resolution Buttons (ar-plusplus)",
+    "url": "https://github.com/altoiddealer/--sd-webui-ar-plusplus.git",
+    "description": "Fork of Aspect Ratio selector plus with advance resolution rounding",
+    "tags": [
+        "UI related"
+    ]
+}

--- a/extensions/sd-webui-ar-plusplus.json
+++ b/extensions/sd-webui-ar-plusplus.json
@@ -1,7 +1,7 @@
 {
     "name": "Aspect Ratio and Resolution Buttons (ar-plusplus)",
     "url": "https://github.com/altoiddealer/--sd-webui-ar-plusplus.git",
-    "description": "Fork of Aspect Ratio selector plus with advance resolution rounding",
+    "description": "Fork of Aspect Ratio selector plus with optimal resolution calculation and rounding",
     "tags": [
         "UI related"
     ]


### PR DESCRIPTION
## Info
https://github.com/altoiddealer/--sd-webui-ar-plusplus.git
another fork of the [sd-webui-ar](https://github.com/alemelis/sd-webui-ar)

@light-and-ray recommended for this one to be added to the index
quote:
> For me, this extension is the best for resolution picking. https://github.com/altoiddealer/--sd-webui-ar-plusplus It has minimalistic ui, and recalculates resolution to match total pixels number
And it also is not in the index. But it's the best I think

---

@altoiddealer we recived a request to add this extentons to the index
when possible we like to confirm with the author before listing it
- are you okay with listing your extension on the index, if not then it won't be listed
- do have any changes you wish to make to the how it's listed (ie description)

if we didn't receive a confirmation with you after a week you will add it to index in this state
should you see this message at a later date and wish to make changes or have it removed please make contact.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
