### PR TITLE
add sd-webui-topaz-photo-ai-integration

### DIFF
--- a/extensions/sd-webui-topaz-photo-ai-integration.json
+++ b/extensions/sd-webui-topaz-photo-ai-integration.json
@@ -1,0 +1,10 @@
+{
+    "name": "Topaz Photo AI integration",
+    "url": "https://github.com/light-and-ray/sd-webui-topaz-photo-ai-integration.git",
+    "description": "Integrates Topaz Photo AI upscaling feature, so you can use it inside hires fix, upscaler_for_img2img or in extras tab",
+    "tags": [
+        "models",
+        "editing",
+        "extras"
+    ]
+}

--- a/extensions/sd-webui-topaz-photo-ai-integration.json
+++ b/extensions/sd-webui-topaz-photo-ai-integration.json
@@ -1,10 +1,11 @@
 {
     "name": "Topaz Photo AI integration",
     "url": "https://github.com/light-and-ray/sd-webui-topaz-photo-ai-integration.git",
-    "description": "Integrates Topaz Photo AI upscaling feature, so you can use it inside hires fix, upscaler_for_img2img or in extras tab",
+    "description": "Integrates Topaz Photo AI Gigapixel upscaling, so you can use it inside hires fix, upscaler_for_img2img or in extras tab; and Sharpen script in extras tab",
     "tags": [
         "models",
         "editing",
+        "script",
         "extras"
     ]
 }

--- a/extensions/sd-webui-topaz-photo-ai-integration.json
+++ b/extensions/sd-webui-topaz-photo-ai-integration.json
@@ -1,9 +1,8 @@
 {
     "name": "Topaz Photo AI integration",
     "url": "https://github.com/light-and-ray/sd-webui-topaz-photo-ai-integration.git",
-    "description": "Integrates Topaz Photo AI Gigapixel upscaling, so you can use it inside hires fix, upscaler_for_img2img or in extras tab; and Sharpen script in extras tab",
+    "description": "Integrates upscaling feature from Topaz's Photo AI paid software, so you can use it inside hires fix, upscaler_for_img2img or in extras tab. Also there is a script for Sharpen and other features inside extras tab",
     "tags": [
-        "models",
         "editing",
         "script",
         "extras"


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-topaz-photo-ai-integration
Integrates Topaz Photo AI upscaling feature, so you can use it inside hires fix, upscaler_for_img2img or in extras tab

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
