### PR TITLE
add Yandere Inpainting as masked content

### DIFF
--- a/extensions/sd-webui-yandere-inpaint-masked-content.json
+++ b/extensions/sd-webui-yandere-inpaint-masked-content.json
@@ -1,0 +1,9 @@
+{
+    "name": "Yandere Inpainting as masked content",
+    "url": "https://github.com/light-and-ray/sd-webui-yandere-inpaint-masked-content.git",
+    "description": "Integrates Yandere Inpainting ESRGAN model into Inpaint tab as masked content method. Fits for removing small objects or watermarks in anime art",
+    "tags": [
+        "UI related",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
## Info 
It's me again
https://github.com/light-and-ray/sd-webui-yandere-inpaint-masked-content
Developed when a person in Discord find this model, and it was easy to modify "lama cleaner as masked contend" for this interesting ESRGAN inpainting model

Integrates Yandere Inpainting ESRGAN model into Inpaint tab as masked content method. Fits for removing small objects or watermarks in anime art

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
