### PR TITLE
add sd-webui-resynthesizer-masked-content

### DIFF
--- a/extensions/sd-webui-resynthesizer-masked-content.json
+++ b/extensions/sd-webui-resynthesizer-masked-content.json
@@ -1,0 +1,9 @@
+{
+    "name": "Resynthesizer as masked content",
+    "url": "https://github.com/light-and-ray/sd-webui-resynthesizer-masked-content.git",
+    "description": "Integrates Resynthesizer old content-aware fill algorithm into Inpaint tab as masked content method",
+    "tags": [
+        "UI related",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-resynthesizer-masked-content

It uses my package I've added in pip https://pypi.org/project/resynthesizer/

I'm not actually sure does it work correctly on Windows. In my virtual machine it works, but result is worse. The same if I built it in linux or in windows vm itself. But I think it's problem in VM, because what could went wrong if I just compiled dll for a different system

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
