### PR TITLE
add manga inpainting

### DIFF
--- a/extensions/sd-webui-manga-inpainting.json
+++ b/extensions/sd-webui-manga-inpainting.json
@@ -1,0 +1,9 @@
+{
+    "name": "Manga Inpainting",
+    "url": "https://github.com/light-and-ray/sd-webui-manga-inpainting.git",
+    "description": "A network for removing something in manga. Requires controlnet and lama-cleaner-masked-content",
+    "tags": [
+        "manipulations",
+        "extras"
+    ]
+}


### PR DESCRIPTION
## Info 
This is an extension for [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui) which adds [msxie92/MangaInpainting](https://github.com/msxie92/MangaInpainting) inside extras tab. Requires [lama-cleaner-masked-content](https://github.com/light-and-ray/sd-webui-lama-cleaner-masked-content) because this extensions compilates all my extra inpainting methods inside extras tab

https://github.com/light-and-ray/sd-webui-manga-inpainting

![](https://github.com/light-and-ray/sd-webui-manga-inpainting/raw/master/images/comparasion.png)

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
