### PR TITLE
Add json for stupid-nsfw-card-blur-a1111 extention

### DIFF
--- a/extensions/stupid-nsfw-card-blur-a1111.json
+++ b/extensions/stupid-nsfw-card-blur-a1111.json
@@ -1,0 +1,8 @@
+{
+    "name": "stupid-nsfw-card-blur-a1111",
+    "url": "https://github.com/CurtisDS/stupid-nsfw-card-blur-a1111.git",
+    "description": "Blurs or hides card thumbnails if the path to the preview thumbnail contains the string 'nsfw'",
+    "tags": [
+        "UI related"
+    ]
+}


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->
https://github.com/CurtisDS/stupid-nsfw-card-blur-a1111/

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
