### PR TITLE
sd-all-prompt-wildcards

### DIFF
--- a/extensions/sd-all-prompt-wildcards.json
+++ b/extensions/sd-all-prompt-wildcards.json
@@ -1,6 +1,6 @@
 {
     "name": "sd-all-prompt-wildcards",
-    "url": "https://github.com/MackinationsAi/sd-all-prompt-wildcards",
+    "url": "https://github.com/MackinationsAi/stable-diffusion-webui-wildcards",
     "description": "Allows the user to use wildcards in both the positive & negative prompt.",
     "added": "2024-08-03",
     "tags": [

--- a/extensions/sd-all-prompt-wildcards.json
+++ b/extensions/sd-all-prompt-wildcards.json
@@ -1,6 +1,6 @@
 {
     "name": "sd-all-prompt-wildcards",
-    "url": "https://github.com/MackinationsAi/stable-diffusion-webui-wildcards",
+    "url": "https://github.com/MackinationsAi/sd-all-prompt-wildcards.git",
     "description": "Allows the user to use wildcards in both the positive & negative prompt.",
     "added": "2024-08-03",
     "tags": [

--- a/extensions/sd-all-prompt-wildcards.json
+++ b/extensions/sd-all-prompt-wildcards.json
@@ -1,0 +1,9 @@
+{
+    "name": "sd-all-prompt-wildcards",
+    "url": "https://github.com/MackinationsAi/sd-all-prompt-wildcards",
+    "description": "Allows the user to use wildcards in both the positive & negative prompt.",
+    "added": "2024-08-03",
+    "tags": [
+        "prompting"
+    ]
+}

--- a/extensions/sd-webui-udav2.json
+++ b/extensions/sd-webui-udav2.json
@@ -1,0 +1,13 @@
+{
+    "name": "sd-webui-udav2",
+    "url": "https://github.com/MackinationsAi/sd-webui-udav2.git",
+    "description": "Integration of the Upgraded-Depth-Anything-V2 - UDAV2 models & UI into an a1111 extension.",
+    "tags": [
+        "tab",
+        "models",
+        "editing",
+        "manipulations",
+        "animation",
+        "extras"
+    ]
+}

--- a/extensions/sd-webui-udav2.json
+++ b/extensions/sd-webui-udav2.json
@@ -4,10 +4,6 @@
     "description": "Integration of the Upgraded-Depth-Anything-V2 - UDAV2 models & UI into an a1111 extension.",
     "tags": [
         "tab",
-        "models",
-        "editing",
-        "manipulations",
-        "animation",
-        "extras"
+        "animation"
     ]
 }


### PR DESCRIPTION
## Info 

Allows the user to use wildcards in both the positive & negative prompt [sd-all-prompt-wildcards](https://github.com/MackinationsAi/sd-all-prompt-wildcards).

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
