### PR TITLE
Add img2img-hires-fix

### DIFF
--- a/extensions/img2img-hires-fix.json
+++ b/extensions/img2img-hires-fix.json
@@ -1,7 +1,7 @@
 {
     "name": "img2img-hires-fix",
     "url": "https://github.com/Amadeus-AI/img2img-hires-fix.git",
-    "description": "Hires-Fix right after the img2img process, using its latent.",
+    "description": "Hires-Fix upscale right after the img2img process, using its latent.",
     "added": "2024-09-02",
     "tags": [
         "script",

--- a/extensions/img2img-hires-fix.json
+++ b/extensions/img2img-hires-fix.json
@@ -1,0 +1,10 @@
+{
+    "name": "img2img-hires-fix",
+    "url": "https://github.com/Amadeus-AI/img2img-hires-fix.git",
+    "description": "Hires-Fix right after the img2img process, using its latent.",
+    "added": "2024-09-02",
+    "tags": [
+        "script",
+        "manipulations"
+    ]
+}

--- a/extensions/img2img-hires-fix.json
+++ b/extensions/img2img-hires-fix.json
@@ -2,7 +2,6 @@
     "name": "img2img-hires-fix",
     "url": "https://github.com/Amadeus-AI/img2img-hires-fix.git",
     "description": "Hires-Fix upscale right after the img2img process, using its latent.",
-    "added": "2024-09-02",
     "tags": [
         "script",
         "manipulations"


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->
* https://github.com/Amadeus-AI/img2img-hires-fix
* Hires fix right after the img2img process, using its latent.
* Inspired by wcde/custom-hires-fix-for-automatic1111, which has been archived and isn't functioning since 2023.
* Originally, if you upscale using/before img2img, the anatomy will be broken at higher resolution.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
