### PR TITLE
Create sd-webui-ask-before-closing.json

### DIFF
--- a/sd-webui-ask-before-closing.json
+++ b/sd-webui-ask-before-closing.json
@@ -1,0 +1,8 @@
+{
+    "name": "Ask before closing",
+    "url": "https://github.com/ruSauron/sd-webui-ask-before-closing.git",
+    "description": "This extension asks for confirmation that you really want to close or refresh the webui page.",
+    "tags": [
+        "UI related"
+    ]
+}


### PR DESCRIPTION
## Info 
<!--- Repo url or any other thing you like to say --->
https://github.com/ruSauron/sd-webui-ask-before-closing.git
Once again accidentally refreshing the webui tab on my phone I was surprised not to find such an option in settings or extensions

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
