### PR TITLE
add sd-webui-vae-tools

### DIFF
--- a/extensions/sd-webui-vae-tools.json
+++ b/extensions/sd-webui-vae-tools.json
@@ -1,0 +1,10 @@
+{
+    "name": "VAE Tools (in extras tab)",
+    "url": "https://github.com/light-and-ray/sd-webui-vae-tools.git",
+    "description": "You can encode, decode images using VAE models inside Extras tab",
+    "tags": [
+        "script",
+        "editing",
+        "extras"
+    ]
+}


### PR DESCRIPTION
## Info 
https://github.com/light-and-ray/sd-webui-vae-tools

Adds a postprocessing script inside Extras tab that allows you to use VAE models on images: encode, decode, encode+decode. It allows you exploring vae compression artifacts, how different vae models work together, and storing images in encoded vae form as a funny cipher

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
