### PR TITLE
Add SD WebUI Watermark Extension

### DIFF
--- a/extensions/sd-webui-watermark.json
+++ b/extensions/sd-webui-watermark.json
@@ -1,0 +1,10 @@
+{
+  "name": "SD WebUI Watermark Extension,
+  "url": "https://github.com/RegulusAlpha/sd-webui-watermark.git",
+  "description": "Adds a customizable text or image watermark to saved generations. Includes font, size, opacity, and placement options. Supports Quicksettings toggling.",
+  "tags": [
+    "script",
+    "editing",
+    "UI related"
+  ]
+}

--- a/extensions/sd-webui-watermark.json
+++ b/extensions/sd-webui-watermark.json
@@ -1,5 +1,5 @@
 {
-  "name": "SD WebUI Watermark Extension,
+  "name": "SD WebUI Watermark Extension",
   "url": "https://github.com/RegulusAlpha/sd-webui-watermark.git",
   "description": "Adds a customizable text or image watermark to saved generations. Includes font, size, opacity, and placement options. Supports Quicksettings toggling.",
   "tags": [


### PR DESCRIPTION
https://github.com/RegulusAlpha/sd-webui-watermark

Adds a configurable watermarking feature to stable-diffusion-webui. This extension allows users to automatically apply a text or image watermark to generated images upon saving. Watermarks are rendered in the bottom-right corner and can be customized via the Settings tab or toggled via Quicksettings.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [X] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [X] The description is written in English.
- [X] The `index.json` and `extension_template.json` have not been modified.
- [X] The `entry` is placed in the `extensions` directory with the `.json` file extension.
