### PR TITLE
add quick segment to extensions list

### DIFF
--- a/extensions/sd-webui-quick-segment.json
+++ b/extensions/sd-webui-quick-segment.json
@@ -1,0 +1,10 @@
+{
+    "name": "sd-webui-quick-segment",
+    "url": "https://github.com/dmikey/sd-webui-quick-segment.git",
+    "description": "Simplified fork of Segment Anything. Focuses on one-click object detection and mask generation using SAM and GroundingDINO. Features presets for body parts, clothing, and faces, with easy integration into img2img inpainting.",
+    "tags": [
+        "script",
+        "dropdown",
+        "UI related"
+    ]
+}


### PR DESCRIPTION
## Info 

[https://github.com/dmikey/sd-webui-quick-segment](https://github.com/dmikey/sd-webui-quick-segment
)
Turns Segment Anything into a Quick Mask / Text Prompt detection system, and adds quick target buttons to Inpaint Upload and Txt2Img/Img2Img , allowing fluid and seamless first time gen, segmentation, and in painting. Is my first extension, if there's an issue do let me know.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
