### PR TITLE
Add Asymmetric Tiling (Forge-compatible)

### DIFF
--- a/extensions/asymmetric-tiling-forge.json
+++ b/extensions/asymmetric-tiling-forge.json
@@ -1,0 +1,9 @@
+{
+    "name": "Asymmetric Tiling (Forge-compatible)",
+    "url": "https://github.com/Dragynrain/asymmetric-tiling-sd-webui.git",
+    "description": "Seamless image tiling configurable independently for X and Y axes. Fork of tjm35/asymmetric-tiling-sd-webui rewritten for Forge compatibility (also works with A1111).",
+    "tags": [
+        "script",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
## Summary

Adds [Asymmetric Tiling (Forge-compatible)](https://github.com/Dragynrain/asymmetric-tiling-sd-webui) to the extensions index.

This is a Forge-compatible fork of the existing [tjm35/asymmetric-tiling-sd-webui](https://github.com/tjm35/asymmetric-tiling-sd-webui) (already indexed). The original does not work with Forge and the maintainer closed Forge support as won't-fix ([tjm35/asymmetric-tiling-sd-webui#16](https://github.com/tjm35/asymmetric-tiling-sd-webui/issues/16)).

This rewrite works with both Forge and A1111. CC0 licensed, same as the original.