### PR TITLE
Add Backblaze B2 Cloud Storage extension

### DIFF
--- a/extensions/stable-diffusion-webui-b2-storage.json
+++ b/extensions/stable-diffusion-webui-b2-storage.json
@@ -1,7 +1,7 @@
 {
     "name": "Backblaze B2 Cloud Storage",
     "url": "https://github.com/mikesibiu/stable-diffusion-webui-b2-storage.git",
-    "description": "Automatically uploads generated images in the background to Backblaze B2 or any S3-compatible storage (AWS S3, Cloudflare R2, MinIO, Wasabi), with optional local disk cleanup after upload.",
+    "description": "Automatically uploads generated images in the background to Backblaze B2 or any S3-compatible storage, with optional local disk cleanup after upload.",
     "tags": [
         "script",
         "online"

--- a/extensions/stable-diffusion-webui-b2-storage.json
+++ b/extensions/stable-diffusion-webui-b2-storage.json
@@ -1,0 +1,9 @@
+{
+    "name": "Backblaze B2 Cloud Storage",
+    "url": "https://github.com/mikesibiu/stable-diffusion-webui-b2-storage.git",
+    "description": "Automatically uploads generated images to a Backblaze B2 bucket in the background (native REST or S3-compatible API), with optional local disk cleanup after upload.",
+    "tags": [
+        "script",
+        "online"
+    ]
+}

--- a/extensions/stable-diffusion-webui-b2-storage.json
+++ b/extensions/stable-diffusion-webui-b2-storage.json
@@ -1,7 +1,7 @@
 {
     "name": "Backblaze B2 Cloud Storage",
     "url": "https://github.com/mikesibiu/stable-diffusion-webui-b2-storage.git",
-    "description": "Automatically uploads generated images to a Backblaze B2 bucket in the background (native REST or S3-compatible API), with optional local disk cleanup after upload.",
+    "description": "Automatically uploads generated images in the background to Backblaze B2 or any S3-compatible storage (AWS S3, Cloudflare R2, MinIO, Wasabi), with optional local disk cleanup after upload.",
     "tags": [
         "script",
         "online"


### PR DESCRIPTION
Adds [stable-diffusion-webui-b2-storage](https://github.com/mikesibiu/stable-diffusion-webui-b2-storage) to the index.

The extension automatically uploads generated images via the `on_image_saved` callback to Backblaze B2 — or any S3-compatible storage, since the S3 API type uses boto3 with a configurable endpoint. Backblaze B2's native REST API is also supported and needs no extra dependencies. Uploads run on a background worker thread so generation is never blocked, and there is an optional setting to delete local copies after successful upload to save disk space.

Follows Backblaze's official integration checklist (upload URL reuse, retry with backoff and Retry-After, re-auth on token expiry, User-Agent identification), supports single-bucket restricted application keys, and ships with unit tests plus an opt-in live integration test suite. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)