### PR TITLE
Added PromptMods extension

### DIFF
--- a/extensions/PromptMods
+++ b/extensions/PromptMods
@@ -1,0 +1,10 @@
+{
+    "name": "PromptMods",
+    "url": "https://github.com/HotChocut/PromptMods.git",
+    "description": "An AUTOMATIC1111 / Forge / reForge WebUI extension that adds text before and after prompts.",
+    "tags": [
+        "dropdown",
+        "prompting",
+        "manipulations"
+    ]
+}


### PR DESCRIPTION
Added PromptMods extension to the extensions directory

## Info 
A simple extension that allows users to automatically add text before and after their prompts.

## Checklist:
<!--- Checkboxes will become clickable after submit, no need to fill them now --->
- [x] I have read the [`Readme.md`](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The `index.json` and `extension_template.json` have not been modified.
- [x] The `entry` is placed in the `extensions` directory with the `.json` file extension.
