### PR TITLE
Add Background Prompter

### DIFF
--- a/extensions/background-prompter.json
+++ b/extensions/background-prompter.json
@@ -1,0 +1,11 @@
+{
+    "name": "Background Prompter",
+    "url": "https://github.com/ukr8b3g-cmyk/Background-Prompter.git",
+    "description": "Image-backed background prompt picker for Forge Neo and ReForge with 592 presets, search, favorites, a side panel, and editable hybrid tag and natural-language output.",
+    "tags": [
+        "script",
+        "tab",
+        "UI related",
+        "prompting"
+    ]
+}


### PR DESCRIPTION
## What changed

- Adds Background Prompter to the extension index.
- Classifies it as a script, tab, UI-related, and prompting extension.

## Why

Background Prompter provides Forge Neo and ReForge users with 592 image-backed background presets, searchable browsing, favorites, a resizable side panel, and editable hybrid tag and natural-language prompt output.

## User impact

After merge and index deployment, users can discover and install the extension from the WebUI Extensions list.

## Validation

- Extension repository is public and installable from the submitted Git URL.
- Registration JSON parses successfully.
- All submitted tags exist in `tags.json`.
- Extension catalog declares 592 presets and includes 592 matching thumbnail images with no missing or duplicate entries.
