### PR TITLE
Add Style Order Manager to extension index

### DIFF
--- a/extensions/Style-Order-Manager.json
+++ b/extensions/Style-Order-Manager.json
@@ -1,0 +1,10 @@
+{
+    "name": "Style Order Manager",
+    "url": "https://github.com/ukr8b3g-cmyk/Style-Order-Manager.git",
+    "description": "A lightweight tab for compact one-line style browsing, drag-and-drop reordering, editing, backup, and restore of styles.csv in Forge Neo and compatible WebUI forks.",
+    "tags": [
+        "tab",
+        "UI related",
+        "prompting"
+    ]
+}


### PR DESCRIPTION
## Summary

- Add Style Order Manager to the WebUI extension index.
- The extension provides a compact one-line view for browsing and drag-and-drop reordering of `styles.csv`.
- It also includes lightweight search, editing, save, backup, and restore features.

## Compatibility

- Forge Neo: verified
- ReForge: verified

The extension repository is available at https://github.com/ukr8b3g-cmyk/Style-Order-Manager.

This PR only adds `extensions/Style-Order-Manager.json`; `index.json` was not edited directly.
