### PR TITLE
Add Forge Neo Resolution Presets

### DIFF
--- a/index.json
+++ b/index.json
@@ -3454,6 +3454,15 @@
                 "extras"
             ],
             "added": "2026-04-03"
+        },
+        {
+            "name": "Forge Neo Resolution Presets",
+            "url": "https://github.com/ukr8b3g-cmyk/Forge-Neo-Resolution-Presets",
+            "description": "Compact model-family resolution presets for Forge Neo txt2img and img2img, with user presets, profile editing, randomization, and an aspect-ratio calculator.",
+            "tags": [
+                "UI related"
+            ],
+            "added": "2026-07-18"
         }
     ]
 }


### PR DESCRIPTION
## What changed

Add `Forge Neo Resolution Presets` to the official extension index.

- Repository: https://github.com/ukr8b3g-cmyk/Forge-Neo-Resolution-Presets
- Tag: `UI related`
- Description: compact model-family resolution presets for Forge Neo txt2img and img2img, with user presets, profile editing, randomization, and an aspect-ratio calculator.

## Why

This extension provides lightweight one-click resolution presets for Forge Neo without replacing the native Width/Height controls or performing image processing.

## Validation

- Parsed `index.json` successfully.
- Confirmed exactly one entry for the repository URL.
- Verified the entry targets the `extensions` branch format and uses the existing `UI related` tag.

This is a draft PR for maintainer review.
