### PR TITLE
Add seven Stable Yogi extensions

### DIFF
--- a/extensions/StableYogi-Tab-Progress.json
+++ b/extensions/StableYogi-Tab-Progress.json
@@ -1,0 +1,9 @@
+{
+    "name": "StableYogi Tab Progress",
+    "url": "https://github.com/Stable-yogi/StableYogi-Tab-Progress.git",
+    "description": "Shows generation progress in the browser tab title (for example [45% ETA 12s]) so you can work in another tab and glance up, plus an optional one-click desktop notification when a run finishes while you are on another tab. Pure front-end; works on Forge, Forge Neo and AUTOMATIC1111.",
+    "tags": [
+        "script",
+        "UI related"
+    ]
+}

--- a/extensions/sd-forge-free-vram.json
+++ b/extensions/sd-forge-free-vram.json
@@ -1,0 +1,9 @@
+{
+    "name": "Free VRAM",
+    "url": "https://github.com/Stable-yogi/sd-forge-free-vram.git",
+    "description": "A one-click button that unloads all models and releases the GPU cache without restarting Forge - hand your VRAM back to another app (LLM, video, another UI), then press Generate to reload on demand. Shows live VRAM and how much it just freed. Uses Forge's own memory manager; zero dependencies.",
+    "tags": [
+        "script",
+        "UI related"
+    ]
+}

--- a/extensions/sd-forge-int8-convrot.json
+++ b/extensions/sd-forge-int8-convrot.json
@@ -1,0 +1,9 @@
+{
+    "name": "INT8-ConvRot Loader",
+    "url": "https://github.com/Stable-yogi/sd-forge-int8-convrot.git",
+    "description": "Load INT8-ConvRot checkpoints in Forge Neo in one click - natively as int8 for better speed and lower VRAM, with no manual dtype selection.",
+    "tags": [
+        "script",
+        "models"
+    ]
+}

--- a/extensions/sd-forge-krea2-enhancements.json
+++ b/extensions/sd-forge-krea2-enhancements.json
@@ -1,0 +1,9 @@
+{
+    "name": "Krea 2 Enhancement Suite",
+    "url": "https://github.com/Stable-yogi/sd-forge-krea2-enhancements.git",
+    "description": "A free companion suite for the Krea 2 Forge Neo extension, adding a prompt-adherence engine and per-layer detail control.",
+    "tags": [
+        "script",
+        "UI related"
+    ]
+}

--- a/extensions/sd-forge-krea2.json
+++ b/extensions/sd-forge-krea2.json
@@ -1,0 +1,9 @@
+{
+    "name": "Krea 2 for Forge Neo",
+    "url": "https://github.com/Stable-yogi/sd-forge-krea2.git",
+    "description": "Run the Krea 2 model natively in Forge Neo, with one-click model download, presets, fp8 and full or piecewise loading.",
+    "tags": [
+        "script",
+        "models"
+    ]
+}

--- a/extensions/sd-forge-save-prompt-txt.json
+++ b/extensions/sd-forge-save-prompt-txt.json
@@ -1,0 +1,9 @@
+{
+    "name": "Save Prompt TXT",
+    "url": "https://github.com/Stable-yogi/sd-forge-save-prompt-txt.git",
+    "description": "Adds a checkbox that saves only the positive prompt as a .txt file next to each generated image - no restart or settings needed. Handy for building LoRA and caption datasets. Works on Forge and AUTOMATIC1111.",
+    "tags": [
+        "script",
+        "UI related"
+    ]
+}

--- a/extensions/sd-native-pause.json
+++ b/extensions/sd-native-pause.json
@@ -1,0 +1,9 @@
+{
+    "name": "Native Pause / Resume",
+    "url": "https://github.com/Stable-yogi/sd-native-pause.git",
+    "description": "Adds a real Pause / Resume to Forge's native generation - hold the current image between sampling steps and resume with no progress lost, even mid-batch (ADetailer / ControlNet / LoRA all still apply). Forge core only offers Interrupt and Skip. Zero dependencies.",
+    "tags": [
+        "script",
+        "UI related"
+    ]
+}


### PR DESCRIPTION
Adding seven small, free, open-source extensions I maintain. All are functional.

- **StableYogi Tab Progress** — generation progress in the browser tab title, plus an optional "notify when done" desktop alert (Forge / Forge Neo / AUTOMATIC1111)
- **Save Prompt TXT** — saves the positive prompt as a .txt next to each image; handy for building datasets (Forge / AUTOMATIC1111)
- **INT8-ConvRot Loader** — one-click loading of INT8-ConvRot checkpoints in Forge Neo
- **Krea 2 for Forge Neo** — run the Krea 2 model natively in Forge Neo
- **Krea 2 Enhancement Suite** — companion controls for the Krea 2 extension
- **Native Pause / Resume** — a real Pause/Resume for Forge's native generation (hold mid-batch and resume with no progress lost; core only has Interrupt/Skip)
- **Free VRAM** — a one-click button to unload all models and release the GPU cache without restarting Forge

Each entry is a single JSON file under `extensions/`, following `extension_template.json` and tagged per `tags.json`. None connect to an external server during regular use (Krea 2 only does a one-time model download), so no `online` tag; none contain ads. Thanks for maintaining the index.
