### PR TITLE
Add eight more Stable Yogi extensions

### DIFF
--- a/extensions/sd-forge-ab-compare.json
+++ b/extensions/sd-forge-ab-compare.json
@@ -1,0 +1,1 @@
+{"name":"A/B Compare","url":"https://github.com/Stable-yogi/sd-forge-ab-compare.git","description":"Drop two generated images and see exactly which settings differ (sampler, steps, CFG, seed, model...) - read from each PNG\u0027s own embedded parameters. Read-only tab.","tags":["script","tab","query"]}

--- a/extensions/sd-forge-contact-sheet.json
+++ b/extensions/sd-forge-contact-sheet.json
@@ -1,0 +1,1 @@
+{"name":"Contact Sheet","url":"https://github.com/Stable-yogi/sd-forge-contact-sheet.git","description":"After a batch, build one labelled grid of the results with each cell tagged by its seed - so you can pick the best image and know its seed. Off by default; never alters your individual images.","tags":["script","UI related"]}

--- a/extensions/sd-forge-gen-history.json
+++ b/extensions/sd-forge-gen-history.json
@@ -1,0 +1,1 @@
+{"name":"Generation History","url":"https://github.com/Stable-yogi/sd-forge-gen-history.git","description":"Logs each generation to a searchable JSON-lines file next to your outputs (time, filename, prompt, full settings) - find any past image\u0027s prompt and settings even after the PNG lost its metadata. Live on/off checkbox. Forge / A1111.","tags":["script","UI related"]}

--- a/extensions/sd-forge-lora-triggers.json
+++ b/extensions/sd-forge-lora-triggers.json
@@ -1,0 +1,1 @@
+{"name":"LoRA Triggers (offline)","url":"https://github.com/Stable-yogi/sd-forge-lora-triggers.git","description":"A tab that reads each LoRA\u0027s trigger words straight from the .safetensors file\u0027s own training metadata - works offline and for your locally-trained LoRAs, not just ones from a website. Read-only.","tags":["script","tab"]}

--- a/extensions/sd-forge-nan-guard.json
+++ b/extensions/sd-forge-nan-guard.json
@@ -1,0 +1,1 @@
+{"name":"Blank-image Guard","url":"https://github.com/Stable-yogi/sd-forge-nan-guard.git","description":"Catches the silent black-image bug (a VAE NaN on fp8/half saves a pure black frame): detects the all-black frame and stamps a clear diagnosis onto it instead of a mystery black square. Only touches already-failed frames.","tags":["script","editing"]}

--- a/extensions/sd-forge-open-outputs.json
+++ b/extensions/sd-forge-open-outputs.json
@@ -1,0 +1,1 @@
+{"name":"Open Output Folder","url":"https://github.com/Stable-yogi/sd-forge-open-outputs.git","description":"One-click buttons to open your images / grids output folders in the file browser, from the txt2img / img2img panel. Reads Forge\u0027s own output settings; never touches generation.","tags":["script","UI related"]}

--- a/extensions/sd-forge-prompt-library.json
+++ b/extensions/sd-forge-prompt-library.json
@@ -1,0 +1,1 @@
+{"name":"Prompt Library","url":"https://github.com/Stable-yogi/sd-forge-prompt-library.git","description":"A tab to save the prompt bits you reuse (quality tags, a go-to negative, a style block) and copy them back any time. Persistent JSON, offline, never touches generation.","tags":["script","tab","prompting"]}

--- a/extensions/sd-forge-watermark.json
+++ b/extensions/sd-forge-watermark.json
@@ -1,0 +1,1 @@
+{"name":"Watermark","url":"https://github.com/Stable-yogi/sd-forge-watermark.git","description":"An opt-in text watermark - stamp your handle on each image before it saves (position, opacity, size, soft shadow). Off by default; drawn with Pillow; never breaks saving.","tags":["script","editing"]}


### PR DESCRIPTION
Adding eight more small, free, open-source extensions I maintain — a follow-up to #434. All are functional and MIT-licensed.

- **Generation History** — logs each generation to a searchable JSON-lines file next to your outputs (find any past image's prompt + settings)
- **LoRA Triggers** — reads a LoRA's trigger words from its own `.safetensors` metadata (offline; works for locally-trained LoRAs)
- **Prompt Library** — save and reuse your go-to prompt snippets
- **Watermark** — opt-in text watermark stamped before saving (off by default)
- **A/B Compare** — drop two images and see which generation settings differ
- **Blank-image Guard** — labels the silent all-black VAE-NaN failure with a clear diagnosis instead of a mystery black square
- **Contact Sheet** — a labelled batch grid, each cell tagged with its seed
- **Open Output Folder** — one-click buttons to open your output folders

Each is a single JSON file under `extensions/`, following `extension_template.json` and tagged per `tags.json`. None connect to an external server (all work offline), so no `online` tag; none contain ads. Thanks again for maintaining the index.
