### PR TITLE
Add Anima LoRA 28→40 Converter (ForgeNeo extension)

### DIFF
--- a/extensions/sd-webui-anima-lora-28to40-converter.json
+++ b/extensions/sd-webui-anima-lora-28to40-converter.json
@@ -1,0 +1,9 @@
+{
+    "name": "Anima LoRA 28→40 Converter",
+    "url": "https://github.com/R0smontis/sd-webui-anima-lora-28to40-converter.git",
+    "description": "Batch convert 28-layer Anima LoRAs to 40-layer key structure and save into models/Lora. Supports lora_unet_blocks_*, diffusion_model.blocks.* and net.blocks.* naming, with optional output key family conversion. Same mapping spec as the ComfyUI counterpart (insertion layers left empty).",
+    "tags": [
+        "tab",
+        "models"
+    ]
+}


### PR DESCRIPTION
## Info 
Repo: https://github.com/R0smontis/sd-webui-anima-lora-28to40-converter

ForgeNeo / SD WebUI Forge extension: batch convert 28-layer Anima LoRAs to the 40-layer key structure and save into models/Lora.

- Dedicated 'Anima LoRA 28→40' tab + POST /anima-lora-converter/convert API
- Same mapping spec as the ComfyUI counterpart: insertion layers 2/5/8/11/14/17/21/24/27/30/33/36 left empty (0→0, 2→3, 14→20, 27→39)
- Supports lora_unet_blocks_*, diffusion_model.blocks.* and net.blocks.* key families, optional cross-family output
- MIT licensed, no extra dependencies, 16 unit tests

## Checklist:
- [x] I have read the [Readme.md](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions)
- [x] The description is written in English.
- [x] The index.json and extension_template.json have not been modified.
- [x] The entry is placed in the extensions directory with the .json file extension.